### PR TITLE
Fix escape-html dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "commander": "^2.9.0",
     "d3-time-format": "^2.0.3",
-    "html-escape": "^2.0.0",
+    "escape-html": "^1.0.3",
     "mustache": "^2.3.0"
   }
 }


### PR DESCRIPTION
`escape-html` is referenced in the code and is the more popular module on NPM, so presumably that was the intended module.