### PR TITLE
Add support for python and clike languages to prismjs highlighting

### DIFF
--- a/components/code.js
+++ b/components/code.js
@@ -1,4 +1,6 @@
 import Prism from "prismjs";
+import "prismjs/components/prism-python"
+import "prismjs/components/prism-clike"
 
 export default function(dom, data) {
   let codeElements = [].slice.call(dom.querySelectorAll("dt-code"));


### PR DESCRIPTION
_WIP - do not merge_ addressing #42 

Shows how to enable syntax highlighting support for additional languages with `prism.js`.

Needs a test—don't yet know the standard for how to do so in this project.
Also needs discussion if we just add a fixed list of useful languages, or if we make this configurable.