### PR TITLE
Restore padding for d-hover-box

### DIFF
--- a/src/components/d-hover-box.js
+++ b/src/components/d-hover-box.js
@@ -30,6 +30,7 @@ const T = Template('d-hover-box', `
   box-shadow: 0 0 7px rgba(0, 0, 0, 0.1);
   border-radius: 4px;
   box-sizing: border-box;
+  padding: 10px;
 }
 
 </style>


### PR DESCRIPTION
Fixes #73. `padding` was removed in 3a643ab. I'm not sure if it was intentional or not so proposing this with a PR just in case. Without padding, footnotes (though not citations) are rendered as so:

![image](https://user-images.githubusercontent.com/42262/35594888-9cb9a3c0-05c9-11e8-8d1b-aebd472505fc.png)