### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To contribute a change, [check out the contributing guide](CONTRIBUTING.md).
 
 ### Local Development
 
-Run `npm run start` to start a watching build rollup server. To view the sample pages in the repo, you can run `npm run serve` as a separate process which starts a static server. `npm run build` will run a one-time build.
+First, run `npm install` to install all node modules required. Then, run `npm run dev` to start a watching build rollup server. To view the sample pages in the repo, you can run `npm run serve` as a separate process which starts a static server. `npm run build` will run a one-time build.
 
 
 ## Disclaimer & License


### PR DESCRIPTION
Uh, this is a small pull request. 

Commit https://github.com/distillpub/template/commit/3a643ab7adea6a8197b3f7c79c4715232991968c changes the rollup server command from `npm run start` to `npm run dev`. I thought it would be helpful to update to README to reflect that change.

I'm also adding a phrase to remind people to run `npm install` before attempting to run any of the commands listed in `package.json`. I figure it can't hurt.