### PR TITLE
Authors HTML generation issue

### DIFF
--- a/src/components/d-byline.js
+++ b/src/components/d-byline.js
@@ -24,11 +24,11 @@ export function bylineTemplate(frontMatter) {
         <p class="author">
           ${author.personalURL ? `
             <a class="name" href="${author.personalURL}">${author.name}</a>` : `
-            <div class="name">${author.name}</div>`}
+            <span class="name">${author.name}</span>`}
         </p>
         <p class="affiliation">
         ${author.affiliations.map(affiliation =>
-          affiliation.url ? `<a class="affiliation" href="${affiliation.url}">${affiliation.name}</a>` : `<div class="affiliation">${affiliation.name}</div>`
+          affiliation.url ? `<a class="affiliation" href="${affiliation.url}">${affiliation.name}</a>` : `<span class="affiliation">${affiliation.name}</span>`
         ).join(', ')}
         </p>
       `).join('')}


### PR DESCRIPTION
I have found out that when you do not define the authorURL, or affiliationURL inside the d-front-matter tag, it tries to create a DIV element within a P tag, which is not allowed by the HTML standard. As a result, the display of the authors and affiliations is incorrect. See https://github.com/distillpub/template/issues/80 for a full description.