### PR TITLE
Correctly parse organization authors in bibtex

### DIFF
--- a/src/helpers/citation.js
+++ b/src/helpers/citation.js
@@ -58,6 +58,11 @@ function author_string(ent, template, sep, finalSep){
   var names = ent.author.split(' and ');
   let name_strings = names.map(name => {
     name = name.trim();
+    if (name.match(/\{.+\}/)) {
+      var regExp = /\{([^}]+)\}/;
+      var matches = regExp.exec(name);
+      return matches[1];
+    }    
     if (name.indexOf(',') != -1){
       var last = name.split(',')[0].trim();
       var firsts = name.split(',')[1];

--- a/src/transforms/citation.js
+++ b/src/transforms/citation.js
@@ -113,6 +113,11 @@ export default function(dom, data) {
     var names = ent.author.split(' and ');
     let name_strings = names.map(name => {
       name = name.trim();
+      if (name.match(/\{.+\}/)) {
+        var regExp = /\{([^}]+)\}/;
+        var matches = regExp.exec(name);
+        return matches[1];
+      }
       if (name.indexOf(',') != -1){
         var last = name.split(',')[0].trim();
         var firsts = name.split(',')[1];


### PR DESCRIPTION
Allow author names enclosed in curly braces to be extracted as is, closes https://github.com/distillpub/template/issues/93.