### PR TITLE
Fix offset calculation in hover box.

### DIFF
--- a/src/components/d-hover-box.js
+++ b/src/components/d-hover-box.js
@@ -70,7 +70,7 @@ export class HoverBox extends T(HTMLElement) {
   }
 
   listen(element) {
-    // console.log(element)
+    // console.log(element);
     this.bindDivEvents(this);
     this.bindTriggerEvents(element);
     // this.style.display = "block";
@@ -128,7 +128,22 @@ export class HoverBox extends T(HTMLElement) {
   showAtNode(node) {
     // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetTop
     const bbox = node.getBoundingClientRect();
-    this.show([node.offsetLeft + bbox.width, node.offsetTop + bbox.height]);
+    const offset = this.calcOffset(node);
+    this.show([offset.left + bbox.width, offset.top + bbox.height]);
+  }
+
+  calcOffset(elem) {
+    let x = elem.offsetLeft;
+    let y = elem.offsetTop;
+
+    // Traverse upwards until an `absolute` element is found or `elem`
+    // becomes null.
+    while (elem = elem.offsetParent && elem.style.position != 'absolute') {
+        x += elem.offsetLeft;
+        y += elem.offsetTop;
+    }
+
+    return { left: x, top: y };
   }
 
   hide() {


### PR DESCRIPTION
Currently, the offset of a hover box is calculated based on `offsetLeft` and `offsetTop`. However, both attributes are relative to the parent, so the citations and footnotes in a table (or other nested elements) may be placed incorrectly.

![original](https://user-images.githubusercontent.com/10289628/57345815-e9922d80-717e-11e9-85d8-dfa94912c42a.gif)

This patch calculates the offset by recursively adding up the offsets of parents. Now the hover boxes appear at the right place.

![fixed](https://user-images.githubusercontent.com/10289628/57345814-e9922d80-717e-11e9-8150-59805e0852f4.gif)

