### PR TITLE
Remove brackets in bibtex entries that are used for plaintext rendering

### DIFF
--- a/examples/bibliography.bib
+++ b/examples/bibliography.bib
@@ -1,5 +1,5 @@
 @article{gregor2015draw,
-  title={DRAW: A recurrent neural network for image generation},
+  title={{D}{R}{A}{W}: A recurrent neural network for image generation},
   author={Gregor, Karol and Danihelka, Ivo and Graves, Alex and Rezende, Danilo Jimenez and Wierstra, Daan},
   journal={arXiv preprint arXiv:1502.04623},
   year={2015},

--- a/examples/bibliography.bib
+++ b/examples/bibliography.bib
@@ -1,5 +1,5 @@
 @article{gregor2015draw,
-  title={{D}{R}{A}{W}: A recurrent neural network for image generation},
+  title={DRAW: A recurrent neural network for image generation},
   author={Gregor, Karol and Danihelka, Ivo and Graves, Alex and Rezende, Danilo Jimenez and Wierstra, Daan},
   journal={arXiv preprint arXiv:1502.04623},
   year={2015},

--- a/src/helpers/bibtex.js
+++ b/src/helpers/bibtex.js
@@ -18,7 +18,8 @@ function normalizeTag(string) {
   return string
     .replace(/[\t\n ]+/g, ' ')
     .replace(/{\\["^`.'acu~Hvs]( )?([a-zA-Z])}/g, (full, x, char) => char)
-    .replace(/{\\([a-zA-Z])}/g, (full, char) => char);
+    .replace(/{\\([a-zA-Z])}/g, (full, char) => char)
+    .replace(/[{}]/gi,'');  // Replace curly braces forcing plaintext in latex.
 }
 
 export function parseBibtex(bibtex) {


### PR DESCRIPTION
Curly braces are used to allow "plaintext" rendering within a bibtex entry.

This change avoids rendering those markup brackets within the bibtex part of the template, along with a change in the example bibliography that demonstrates that this change is working.

Before:
![image](https://user-images.githubusercontent.com/644805/58972198-fe1c1280-878a-11e9-9324-f13ac0711c60.png)


After:
![image](https://user-images.githubusercontent.com/644805/58972150-e6dd2500-878a-11e9-8e27-787e0c664776.png)
