### PR TITLE
Update hover citations when there no authors 

### DIFF
--- a/src/helpers/citation.js
+++ b/src/helpers/citation.js
@@ -193,8 +193,17 @@ export function hover_cite(ent) {
     cite += "<br>";
 
     var a_str = author_string(ent, "${I} ${L}", ", ") + ".";
+    if (a_str.trim() === '.') {
+      a_str = '';  
+    }
+    
     var v_str =
       venue_string(ent).trim() + " " + ent.year + ". " + doi_string(ent, true);
+    
+    if (!a_str.length) {
+      cite += v_str;
+      return cite;
+    }
 
     if ((a_str + v_str).length < Math.min(40, ent.title.length)) {
       cite += a_str + " " + v_str;


### PR DESCRIPTION
When a citation does not include an author entry the citation is formatted correctly in the bibliography, but not in the tooltip. This updates the logic to remove a stray period that is inserted when no author is associated with a bibtex entry.

cc @fredhohman