### PR TITLE
Do not format author names enclosed in curly brackets

### DIFF
--- a/src/helpers/bibtex.js
+++ b/src/helpers/bibtex.js
@@ -19,7 +19,6 @@ function normalizeTag(string) {
     .replace(/[\t\n ]+/g, ' ')
     .replace(/{\\["^`.'acu~Hvs]( )?([a-zA-Z])}/g, (full, x, char) => char)
     .replace(/{\\([a-zA-Z])}/g, (full, char) => char)
-    .replace(/[{}]/gi,'');  // Replace curly braces forcing plaintext in latex.
 }
 
 export function parseBibtex(bibtex) {

--- a/src/helpers/citation.js
+++ b/src/helpers/citation.js
@@ -61,6 +61,11 @@ function author_string(ent, template, sep, finalSep) {
   var names = ent.author.split(" and ");
   let name_strings = names.map(name => {
     name = name.trim();
+    if (name.match(/\{.+\}/)) {
+      var regExp = /\{([^}]+)\}/;
+      var matches = regExp.exec(name);
+      return matches[1];
+    } 
     if (name.indexOf(",") != -1) {
       var last = name.split(",")[0].trim();
       var firsts = name.split(",")[1];
@@ -114,7 +119,7 @@ function venue_string(ent) {
     cite += ent.publisher;
     if (cite[cite.length - 1] != ".") cite += ".";
   }
-  return cite;
+  return cite.replace(/[{}]/gi,'');
 }
 
 function link_string(ent) {
@@ -148,7 +153,7 @@ function doi_string(ent, new_line) {
 }
 
 function title_string(ent) {
-  return '<span class="title">' + ent.title + "</span> ";
+  return '<span class="title">' + ent.title.replace(/[{}]/gi,'') + "</span> ";
 }
 
 export function bibliography_cite(ent, fancy) {
@@ -188,7 +193,7 @@ export function bibliography_cite(ent, fancy) {
 export function hover_cite(ent) {
   if (ent) {
     var cite = "";
-    cite += "<strong>" + ent.title + "</strong>";
+    cite += "<strong>" + ent.title.replace(/[{}]/gi,'') + "</strong>";
     cite += link_string(ent);
     cite += "<br>";
 

--- a/src/transforms/citation.js
+++ b/src/transforms/citation.js
@@ -113,6 +113,11 @@ export default function(dom, data) {
     var names = ent.author.split(' and ');
     let name_strings = names.map(name => {
       name = name.trim();
+      if (name.match(/\{.+\}/)) {
+        var regExp = /\{([^}]+)\}/;
+        var matches = regExp.exec(name);
+        return matches[1];
+      } 
       if (name.indexOf(',') != -1){
         var last = name.split(',')[0].trim();
         var firsts = name.split(',')[1];
@@ -153,7 +158,7 @@ export default function(dom, data) {
       cite += ent.publisher;
       if (cite[cite.length-1] != '.') cite += '.';
     }
-    return cite;
+    return cite.replace(/[{}]/gi,'');
   }
 
   function link_string(ent){
@@ -186,7 +191,7 @@ export default function(dom, data) {
 
   function bibliography_cite(ent, fancy){
     if (ent){
-      var cite =  '<b>' + ent.title + '</b> ';
+      var cite =  '<b>' + ent.title.replace(/[{}]/gi,'') + '</b> ';
       cite += link_string(ent) + '<br>';
       cite += author_string(ent, '${L}, ${I}', ', ', ' and ');
       if (ent.year || ent.date){
@@ -216,7 +221,7 @@ export default function(dom, data) {
   function hover_cite(ent){
     if (ent){
       var cite = '';
-      cite += '<b>' + ent.title + '</b>';
+      cite += '<b>' + ent.title.replace(/[{}]/gi,'') + '</b>';
       cite += link_string(ent);
       cite += '<br>';
 


### PR DESCRIPTION
This is based on the solution in https://github.com/distillpub/template/pull/98, though with a few updates. 
The change in https://github.com/distillpub/template/pull/106 has been reverted because it removes curly braces before formatting takes place. This string replacement is now applied in each relevant part of the reference formatting. 

This is not the ideal solution. A better system of bibtex parsing and citation formatting system is needed for a more general solution. But because referencing organizations is the most common use of curly brackets, this should be good enough for now.