### PR TITLE
content-reference

### DIFF
--- a/examples/content-ref.html
+++ b/examples/content-ref.html
@@ -1,0 +1,78 @@
+
+<!--
+  Copyright 2018 The Distill Template Authors
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!doctype html>
+
+<head>
+  <script src="../dist/template.v2.js"></script>
+
+</head>
+
+<body>
+  <d-byline></d-byline>
+  <d-article>
+
+<br>
+<br>
+<div id="definition 1.6">
+<p>
+<strong>Definition 1.6</strong>
+        Let <d-math>X</d-math> and <d-math>Y</d-math> be sets. For all <d-math>x\in X</d-math> and <d-math>y\in Y</d-math> the <i>pair</i> <d-math>(x,y)</d-math> is defined as
+        the set <d-math>\big\{ \{x \}, \{ x, y \} \big\}</d-math>. The <i>cartesian product</i>
+        <d-math>X \times Y</d-math> is defined as 
+        <br><br><d-math block>
+          \big\{ z \in \mathscr{P}(\mathscr{P}(X \cup Y)) \mid \exists x \in X \, \exists y \in Y : \: 
+          z = \{ \{x \}, \{ x, y \}\} \big\}  .
+</d-math>
+</p>
+</div>
+<br>
+<p>
+See <d-content-ref val="(1.6)" ref="definition 1.6"></d-content-ref> as an example. <d-content-ref val="(1.6)" ref="definition 1.6"></d-content-ref> Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. </p>
+<div id="proposition 1.8">
+    <p>
+<strong>Proposition 1.8</strong>
+  Let <d-math>L, M, N</d-math> be sets. Then the following associativity law for the cartesian product is satisfied:
+  
+  </p><ol class='enumeration'>
+
+  <li value='(a)'> 
+      <d-math>L \times (M \times N)  = (L \times M) \times N</d-math>.
+  
+  </li></ol><p>
+
+  Moreover, the following distributivity laws hold true:
+  
+  </p><ol class='enumeration'>
+
+  <li value='(a)'> 
+      <d-math>L \times (M \cup N)  = (L \times M) \cup (L \times N)</d-math> and   
+      <d-math>(M \cup N) \times L = (M \times L) \cup (N \times L)</d-math>,
+  </li><li value='(b)'>
+      <d-math>L \times (M \cap N)  = (L \times M) \cap (L \times N)</d-math> and   
+      <d-math>(M \cap N) \times L = (M \times L) \cap (N \times L)</d-math>, 
+  </li><li value='(c)'>
+      <d-math>L \times (M \setminus N)  = (L \times M) \setminus (L \times N)</d-math> and   
+      <d-math>(M \setminus N) \times L = (M \times L) \setminus (N \times L)</d-math>.
+  
+  </li></ol><p>
+</p></div> <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt 
+<d-content-ref val="(1.8)" ref="proposition 1.8"></d-content-ref> ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+</p>
+  </d-article>
+  
+</body>
+

--- a/src/components.js
+++ b/src/components.js
@@ -28,6 +28,7 @@ import { Byline }          from './components/d-byline';
 import { Cite }            from './components/d-cite';
 import { CitationList }    from './components/d-citation-list';
 import { Code }            from './components/d-code';
+import { ContentRef }            from './components/d-content-ref';
 import { Footnote }        from './components/d-footnote';
 import { FootnoteList }    from './components/d-footnote-list';
 import { FrontMatter }     from './components/d-front-matter';
@@ -83,7 +84,7 @@ const initialize = function() {
 
   /* 4. Register components */
   const components = [
-    Abstract, Appendix, Article, Bibliography, Byline, Cite, CitationList, Code,
+    Abstract, Appendix, Article, Bibliography, Byline, Cite, CitationList, Code,ContentRef,
     Footnote, FootnoteList, FrontMatter, HoverBox, Title, DMath, References, TOC, Figure,
     Slider, Interstitial
   ];

--- a/src/components/d-content-ref.js
+++ b/src/components/d-content-ref.js
@@ -1,0 +1,69 @@
+// Copyright 2018 The Distill Template Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Template } from '../mixins/template.js';
+
+const T = Template('d-content-ref', `
+<style>
+
+d-math[block] {
+  display: block;
+}
+
+:host {
+
+}
+
+
+span {
+  color: hsla(206, 90%, 20%, 0.7);
+  cursor: default;
+}
+
+.content-ref-container {
+  padding: 10px;
+}
+
+</style>
+
+<d-hover-box>
+  <div class="content-ref-container">
+    <slot id="slot"></slot>
+  </div>
+</d-hover-box>
+
+<span id="fn-" data-hover-ref=""></span>
+
+`);
+
+
+export class ContentRef extends T(HTMLElement) {
+
+  connectedCallback() {
+      var ref = this.getAttribute('ref')
+      ref = document.getElementById(ref);
+      ref = ref.innerHTML
+      this.innerHTML = ref
+      this.hoverBox = this.root.querySelector('d-hover-box');
+      const val = this.getAttribute('val')
+
+      window.customElements.whenDefined('d-hover-box').then(() => {
+        this.hoverBox.listen(this);
+      }
+      );
+      const span = this.root.querySelector('#fn-');
+      span.textContent = val;
+
+      }
+}  


### PR DESCRIPTION
Hello i wrote a class to reference content in the html text itself its really easy to setup and visualizes propositions or theorems in a new window like footnote does. 
![definition_example](https://user-images.githubusercontent.com/63510484/125679248-8076e2d2-42db-4057-8eec-4578b73c84f6.jpg)

All some one needs to do is define a div or span which should be referenced later on `<div id="proposition 1.8"> some math <div>` and then later reference the div with `<d-content-ref val="(1.8)" ref="proposition 1.8"></d-content-ref>` as shown below
![definition_code](https://user-images.githubusercontent.com/63510484/125679306-5d318ca6-c0d0-47a2-a9b1-ec61f33e7758.jpg)
